### PR TITLE
feat: pass spider args to subprocess environment

### DIFF
--- a/requests_entrypoint/utils.py
+++ b/requests_entrypoint/utils.py
@@ -18,6 +18,7 @@ def get_args_and_env(msg):
         "ESTELA_COLLECTION": msg["collection"],
         "ESTELA_UNIQUE_COLLECTION": msg["unique"],
         "ESTELA_CONTEXT": "remote",
+        "ESTELA_SPIDER_ARGS": json.dumps(msg.get("args", {})),
     }
     return args, env
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
 boto3
 estela-queue-adapter @ git+https://github.com/bitmakerla/estela-queue-adapter.git
-estela-requests
+estela-requests @ git+https://github.com/bitmakerla/estela-requests.git

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         "requests",
         "boto3",
         "estela-queue-adapter @ git+https://github.com/bitmakerla/estela-queue-adapter.git",
-        "estela-requests",
+        "estela-requests @ git+https://github.com/bitmakerla/estela-requests.git",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
## Summary
- Pass `ESTELA_SPIDER_ARGS` (JSON-serialized dict) from `JOB_INFO["args"]` to the spider subprocess environment
- Point `estela-requests` dependency to GitHub (git install) instead of PyPI

## Details
Spider arguments passed via `estela create job <SID> -a key=value` are stored in `JOB_INFO["args"]` but were never forwarded to the spider process. This change serializes them as JSON into the `ESTELA_SPIDER_ARGS` env var so spiders can read them at runtime.

## Test plan
- [ ] Deploy a spider with `-a month=02/2026` and verify `ESTELA_SPIDER_ARGS` is set in the subprocess
- [ ] Verify existing spiders without args still work (defaults to `"{}"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)